### PR TITLE
Fix removed mtl reexports

### DIFF
--- a/src/Control/Monad/Heap/List.hs
+++ b/src/Control/Monad/Heap/List.hs
@@ -39,7 +39,8 @@ import Control.Monad.Trans ( MonadTrans(..) )
 import Control.Monad.State ( MonadState(..) )
 import Control.Monad.Except ( MonadError(..) )
 import Control.Monad.Reader ( MonadReader(..) )
-import Control.Monad.Writer ( Alt(Alt), MonadWriter(..) )
+import Control.Monad.Writer ( MonadWriter(..) )
+import Data.Monoid (Alt(Alt))
 import Control.Monad.Cont ( MonadCont(..) )
 import Test.QuickCheck
     ( Arbitrary(..),

--- a/src/MonusWeightedSearch/Examples/Dijkstra.hs
+++ b/src/MonusWeightedSearch/Examples/Dijkstra.hs
@@ -33,7 +33,7 @@ import Prelude hiding (head)
 import Control.Monad.State.Strict
 import Control.Applicative
 import Control.Monad.Writer
-import Control.Monad (MonadPlus(..))
+import Control.Monad
 import Data.Foldable
 
 import Data.Monus.Dist

--- a/src/MonusWeightedSearch/Examples/Dijkstra.hs
+++ b/src/MonusWeightedSearch/Examples/Dijkstra.hs
@@ -33,6 +33,7 @@ import Prelude hiding (head)
 import Control.Monad.State.Strict
 import Control.Applicative
 import Control.Monad.Writer
+import Control.Monad (MonadPlus(..))
 import Data.Foldable
 
 import Data.Monus.Dist

--- a/src/MonusWeightedSearch/Examples/Parsing.hs
+++ b/src/MonusWeightedSearch/Examples/Parsing.hs
@@ -23,6 +23,7 @@ import Control.Monad.Heap
 import Control.Monad.State
 import Data.Monus.Prob
 import Control.Monad.Writer
+import Control.Monad (guard)
 
 -- | A standard parser type.
 --

--- a/src/MonusWeightedSearch/Examples/SubsetSum.hs
+++ b/src/MonusWeightedSearch/Examples/SubsetSum.hs
@@ -14,6 +14,7 @@ import Control.Monad.Heap
 import Data.Monus.Dist
 import Control.Monad.Writer
 import Data.Maybe
+import Control.Monad (filterM, guard)
 
 -- | A weight for the inclusion or exclusion of an element.
 --

--- a/src/MonusWeightedSearch/Examples/Viterbi.hs
+++ b/src/MonusWeightedSearch/Examples/Viterbi.hs
@@ -18,6 +18,7 @@ module MonusWeightedSearch.Examples.Viterbi where
 import Control.Monad.Heap
 import Data.Monus.Prob
 import Control.Monad.Writer
+import Control.Monad (guard)
 import Data.Maybe
 
 -- $setup


### PR DESCRIPTION
The mtl library recently removed re-exports for Control.Monad and Data.Monoid. This pr adds explicit imports where necessary, and should be backwards compatible.

I fixed the errors as they cropped up when building the dependency, so it's one commit per file. Sorry about that, probably a good idea to squash them.